### PR TITLE
Fix duplicate attribute value query

### DIFF
--- a/src/workflows/attribute-value/steps/validate-attribute-value.ts
+++ b/src/workflows/attribute-value/steps/validate-attribute-value.ts
@@ -88,13 +88,12 @@ export const validateAttributeValueStep = createStep(
       fields: [
         "attribute_value.id",
         "attribute_value.value",
-        "attribute_value.attribute.id"
       ],
       filters: {
         product_id: input.product_id,
-        "attribute_value.attribute.id": input.attribute_id,
-        "attribute_value.value": input.value
-      }
+        "attribute_value.attribute_id": input.attribute_id,
+        "attribute_value.value": input.value,
+      },
     });
 
     if (existingLinks.length > 0) {

--- a/src/workflows/attribute-value/steps/validate-attribute-value.ts
+++ b/src/workflows/attribute-value/steps/validate-attribute-value.ts
@@ -83,6 +83,7 @@ export const validateAttributeValueStep = createStep(
     }
 
     // Check for duplicate attribute values on the same product using the link entity
+    // Filter using attribute_value.attribute_id directly to avoid joining the attribute table
     const { data: existingLinks } = await query.graph({
       entity: attributeValueProduct.entryPoint,
       fields: [


### PR DESCRIPTION
## Summary
- fix query for existing attribute value by referencing attribute_id directly

## Testing
- `yarn build` *(fails: medusa not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841febc050c8327bab6b00002c86230